### PR TITLE
Add silverbullet-cli package

### DIFF
--- a/fix_treefmt.sh
+++ b/fix_treefmt.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sed -i 's/^  __structuredAttrs = true;$/  __structuredAttrs = true;/g' pkgs/by-name/si/silverbullet-cli/package.nix
+sed -i '/^  __structuredAttrs = true;$/!b;n;n;d' pkgs/by-name/si/silverbullet-cli/package.nix

--- a/pkgs/by-name/si/silverbullet-cli/package.nix
+++ b/pkgs/by-name/si/silverbullet-cli/package.nix
@@ -10,6 +10,9 @@
 stdenvNoCC.mkDerivation (finalAttrs: {
   pname = "silverbullet-cli";
   version = "2.6.1";
+  strictDeps = true;
+  __structuredAttrs = true;
+
 
   src =
     finalAttrs.passthru.sources.${stdenv.hostPlatform.system}

--- a/pkgs/by-name/si/silverbullet-cli/package.nix
+++ b/pkgs/by-name/si/silverbullet-cli/package.nix
@@ -13,7 +13,6 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   strictDeps = true;
   __structuredAttrs = true;
 
-
   src =
     finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
       or (throw "Unsupported system: ${stdenv.hostPlatform.system}");

--- a/pkgs/by-name/si/silverbullet-cli/package.nix
+++ b/pkgs/by-name/si/silverbullet-cli/package.nix
@@ -1,0 +1,70 @@
+{
+  autoPatchelfHook,
+  common-updater-scripts,
+  fetchzip,
+  lib,
+  stdenv,
+  stdenvNoCC,
+  writeShellScript,
+}:
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "silverbullet-cli";
+  version = "2.6.1";
+
+  src =
+    finalAttrs.passthru.sources.${stdenv.hostPlatform.system}
+      or (throw "Unsupported system: ${stdenv.hostPlatform.system}");
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  buildInputs = [ stdenv.cc.cc.lib ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin
+    install -Dm755 $src/silverbullet-cli $out/bin/silverbullet-cli
+    runHook postInstall
+  '';
+
+  passthru = {
+    sources = {
+      "x86_64-linux" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-linux-x86_64.zip";
+        hash = "sha256-zE8phpI69COeuJ7yOG5jPo/Qp4TjxmyHD4rOsaIwCrI=";
+        stripRoot = false;
+      };
+      "aarch64-linux" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-linux-aarch64.zip";
+        hash = "sha256-nrTjWWUUdeQSsPKHqoIYNkNAhmEjeqVWDWjMHyhQfPQ=";
+        stripRoot = false;
+      };
+      "x86_64-darwin" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-darwin-x86_64.zip";
+        hash = "sha256-OuWd0Iw/WZ97GbexhDkUXb+wDM5x+SJ4iGRINXan4Jw=";
+        stripRoot = false;
+      };
+      "aarch64-darwin" = fetchzip {
+        url = "https://github.com/silverbulletmd/silverbullet/releases/download/${finalAttrs.version}/silverbullet-cli-darwin-aarch64.zip";
+        hash = "sha256-7WMoHBfEVSFatLmKuEegSp02sAe4zt5csHrzDq/11ng=";
+        stripRoot = false;
+      };
+    };
+
+    updateScript = writeShellScript "update-silverbullet-cli" ''
+      NEW_VERSION="$1"
+      for platform in ${lib.escapeShellArgs finalAttrs.meta.platforms}; do
+        ${lib.getExe' common-updater-scripts "update-source-version"} "silverbullet-cli" "$NEW_VERSION" --ignore-same-version --source-key="sources.$platform"
+      done
+    '';
+  };
+
+  meta = {
+    changelog = "https://github.com/silverbulletmd/silverbullet/blob/${finalAttrs.version}/website/CHANGELOG.md";
+    description = "CLI for SilverBullet, an open-source, self-hosted, offline-capable Personal Knowledge Management (PKM) web application";
+    homepage = "https://silverbullet.md";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ aorith ];
+    mainProgram = "silverbullet-cli";
+    platforms = builtins.attrNames finalAttrs.passthru.sources;
+  };
+})


### PR DESCRIPTION
This commit adds a new `silverbullet-cli` package to `nixpkgs` under `pkgs/by-name/si/silverbullet-cli/`. It fetches pre-compiled binaries for Linux and Darwin (x86_64 and aarch64) from upstream GitHub releases for version `2.6.1`. It also includes an update script.

---
*PR created automatically by Jules for task [12705799296729014883](https://jules.google.com/task/12705799296729014883) started by @gleber*